### PR TITLE
Generalize canvas3d (drawing on motion/release, background color)

### DIFF
--- a/src/canvas3d.jl
+++ b/src/canvas3d.jl
@@ -90,10 +90,10 @@ function draw(gc, this::Canvas3D, motion::Bool)
 
     edges = sortby(cube4sides, p->mean(bv[3,:][p]))
 
-    set_source_rgb(gc, this.colorbg.r, this.colorbg.g, this.colorbg.b)
+    set_source_rgb(gc, this.colorbg)
     paint(gc)
 
-    set_source_rgb(gc, this.colorcube.r, this.colorcube.g, this.colorcube.b)
+    set_source_rgb(gc, this.colorcube)
     set_line_width(gc, 0.6)
 
     polygon(gc, bv, edges[1])


### PR DESCRIPTION
These changes are intended to make it easier to use canvas3d for a
wider variety of applications.
- Control over background and wireframe colors: for some applications
  like fluorescence microscopy, black is the natural background color.
- For some applications, calculating the projection might be
  slow. Therefore I added the ability to have the redraw do different
  things on mouse motion and button release (the "crude, fast" version
  could be used for motion, and the "high quality" could be used for
  release).
- Fixes deprecation diagmm -> scale
