### PR TITLE
On-screen plotting example

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ Winston: 2D Plotting for Julia
     p = FramedPlot()
     add(p, Curve(x, y))
 
-    file(p, "winston.eps")
+    Winston.display(p)      # Display the plot on-screen
+    file(p, "winston.eps")  # Save the plot to a file
 
 Installation
 ------------


### PR DESCRIPTION
This adds a call to `Winston.display(p)` to the README example, to display the plot on screen. On-screen windows are the most common way MATLAB and Octave users interact with their plots, so it makes sense to showcase this functionality of Winston too.
