### PR TITLE
plothist(x) now uses hist(x), fix ticks on x

### DIFF
--- a/src/plot.jl
+++ b/src/plot.jl
@@ -204,10 +204,13 @@ spy(S::SparseMatrixCSC) = spy(S, 100, 100)
 spy(A::AbstractMatrix, nrS, ncS) = spy(sparse(A), nrS, ncS)
 spy(A::AbstractMatrix) = spy(sparse(A))
 
-function plothist(x::AbstractVector, nbins)
+function plothist(h::(Range,Vector))
     p = FramedPlot()
-    add(p, Histogram(hist(x, nbins)[2], 1))
+    add(p, Histogram(h[2], isa(h[1],Range1)? 1 : h[1].step))
+    setattr(p.x1, "ticks",[ h[1] ] .- h[1].start)
+    setattr(p.x1, "ticklabels",map(string,h[1]))
     display(p)
 end
 
-plothist(x) = plothist(x, 20)
+plothist(x::AbstractVector, nbins) = plothist(hist(x,nbins))
+plothist(x::AbstractVector) = plothist(hist(x))


### PR DESCRIPTION
`Histogram` on Winston.jl set `x0` to 0 by default (have a fix me comment) and I don't know how to fix it.
For fix it on `plothist()`, I subtract the `start` of the range to ticks (in order to start on 0), but I use the range for labels in order to get the desired output.
Works fine. Sometimes when the number of bins is too large or the labels have to much digits, the labels superpose between them, but can be fixed by user setting a `nbins` to a lower number for example.

```
file( plothist( randn(10000) ) , "hist.png" )
```

![hist](https://f.cloud.github.com/assets/2822757/690509/9993ca58-daff-11e2-8858-31dd24757571.png)
