### PR TITLE
changes needed to track Gtk master

### DIFF
--- a/src/canvas3d.jl
+++ b/src/canvas3d.jl
@@ -277,9 +277,12 @@ end
 
 function plot3d(o::Polygons3D)
     w = Window("3d plot", 320, 320)
-    c = Canvas(w)
     if output_surface == :tk
+        c = Canvas(w)
         pack(c, expand = true, fill = "both")
+    else
+        c = Canvas()
+        push!(w, c)
     end
 
     xmin = min(o.V[1,:]); xmax = max(o.V[1,:])

--- a/src/gtk.jl
+++ b/src/gtk.jl
@@ -1,16 +1,16 @@
 import Gtk
 
-function GTKdrawingwindow(name, w, h, closecb=nothing)
-    win = Gtk.Window(name, w, h)
-    c = Gtk.Canvas(win)
+function Gtkdrawingwindow(name, w, h, closecb=nothing)
+    c = Gtk.Canvas()
+    win = Gtk.Window(c, name, w, h)
     if closecb !== nothing
-        Gtk.on_signal_destroy(win, closecb, win)
+        Gtk.on_signal_destroy(closecb, win)
     end
     c, win
 end
 
 _saved_gtk_renderer = nothing
-function _saved_gtk_destroyed(::Ptr, widget::Gtk.GTKWidget)
+function _saved_gtk_destroyed(::Ptr, widget)
     global _saved_gtk_renderer = nothing
     nothing
 end
@@ -22,7 +22,7 @@ function gtk(self::PlotContainer, args...)
     reuse_window = isinteractive() #&& Winston.config_value("window","reuse")
     device = _saved_gtk_renderer
     if device === nothing || !reuse_window
-        device, win = GTKdrawingwindow("Julia", width, height, _saved_gtk_destroyed)
+        device, win = Gtkdrawingwindow("Julia", width, height, _saved_gtk_destroyed)
         _saved_gtk_renderer = device
     end
     display(device, self)


### PR DESCRIPTION
I've switched widget constructors in Gtk to take their child elements as parameters, instead of the parent element. I've been working on this change for awhile, but just finally pushed it to the master branch of Gtk.jl. I'll bump the version number in METADATA shortly.
