### PR TITLE
add smoothing to plothist2d

### DIFF
--- a/src/plot.jl
+++ b/src/plot.jl
@@ -261,12 +261,25 @@ plothist(args...; kvs...) = plothist(FramedPlot(), args...; kvs...)
 # shortcut for overplotting
 oplothist(args...; kvs...) = plothist(_pwinston, args...; kvs...)
 
+# 3x3 gaussian
+#_default_kernel2d=[.05 .1 .05; .1 .4 .1; .05 .1 .05]
+
+# 5x5 gaussian
+_default_kernel2d=(1.0/273.)*[1.0 4.0 7.0 4.0 1.0;
+                             4.0 16. 26. 16. 4.0;
+                             7.0 26. 41. 26. 7.0;
+                             1.0 4.0 7.0 4.0 1.0;
+                             4.0 16. 26. 16. 4.0]                 
+
 #hist2d
-function plothist2d(p::FramedPlot, h::(Union(Range,Vector),Union(Range,Vector),Array{Int,2}); colormap=_default_colormap, kvs...)
+function plothist2d(p::FramedPlot, h::(Union(Range,Vector),Union(Range,Vector),Array{Int,2}); colormap=_default_colormap, smooth=0, kernel=_default_kernel2d, kvs...)
     xr, yr, hdata = h
 
-    clims = (minimum(hdata), maximum(hdata)+1)
+    for i in 1:smooth
+        hdata = conv2(hdata*1.0, kernel)
+    end
 
+    clims = (minimum(hdata), maximum(hdata)+1)
     img = data2rgb(hdata, clims, colormap)'
     add(p, Image((xr[1], xr[end]), (yr[1], yr[end]), img;))
 


### PR DESCRIPTION
This adds option to smooth 2 dimensional histograms with gaussian kernel (or by user defined kernel). Works by defining the amount of smooth with named variable `smooth`, something like this:

``` julia
plothist2d(hd,range,range,xrange=(-3,3),yrange=(-3,3),smooth=2)
```

and produces this:
![fig2dim](https://f.cloud.github.com/assets/3612029/1524030/f95537de-4bbf-11e3-83c3-8334345887ba.png)

Might be too experimental feature but dunno, merge if you want.
