### PR TITLE
Make `plot` work with one complex argument as in MATLAB

### DIFF
--- a/src/plot_interfaces.jl
+++ b/src/plot_interfaces.jl
@@ -51,6 +51,10 @@ function plot(p::FramedPlot, fs::Vector{Function}, a::Real, b::Real, args...; kw
     
 end
 
+## complex argument plot
+plot{T<:Complex}(z::AbstractVector{T}, args...; kvs...) =
+    plot(real(z), imag(z), args...; kvs...)
+
 ## parametric plot
 typealias ParametricFunctionPair (Function, Function)
 function plot(p::FramedPlot, fs::ParametricFunctionPair, a::Real, b::Real, args...; npoints::Int=500, kwargs...)


### PR DESCRIPTION
Make `plot` work with one complex argument as in MATLAB. For example:

``` julia
using Winston
t=[0:pi/10:2*pi]
plot(exp(t*im),"o-")
```
