### PR TITLE
Allow colors to be specified with RGBA (support transparency)

### DIFF
--- a/src/renderer.jl
+++ b/src/renderer.jl
@@ -63,6 +63,7 @@ color_to_rgb(i::Integer) = convert(RGB, RGB24(unsigned(i)))
 color_to_rgb(s::String) = color(s)
 color_to_rgb(rgb::(Real,Real,Real)) = RGB(rgb...)
 color_to_rgb(cv::ColorValue) = convert(RGB, cv)
+color_to_rgb(cv::AlphaColorValue) = cv
 
 set_color(ctx::CairoContext, color) = set_source(ctx, color_to_rgb(color))
 


### PR DESCRIPTION
A nice approach for representing error bars of multiple lines on a single plot uses `FillBetween` with a transparent color.

This relies on https://github.com/JuliaLang/Color.jl/pull/16 and https://github.com/JuliaLang/Cairo.jl/pull/64, so don't merge yet.
