### PR TITLE
Allow users to specify no display

### DIFF
--- a/src/Winston.jl
+++ b/src/Winston.jl
@@ -2613,8 +2613,12 @@ end
 writemime(io::IO, ::MIME"image/png", p::PlotContainer) =
     write_png(p, io, _ijulia_width, _ijulia_height)
 
-output_surface = Winston.config_value("default","output_surface")
-output_surface = symbol(lowercase(get(ENV, "WINSTON_OUTPUT", output_surface)))
+if isdefined(Main, :IJulia)
+    output_surface = :none
+else
+    output_surface = Winston.config_value("default","output_surface")
+    output_surface = symbol(lowercase(get(ENV, "WINSTON_OUTPUT", output_surface)))
+end
 
 type Figure
     window
@@ -2686,7 +2690,7 @@ end
 gcf() = _display.current_fig
 closefig() = closefig(_display.current_fig)
 
-if !isdefined(Main, :IJulia)
+if output_surface != :none
     if output_surface == :gtk
         include("gtk.jl")
         window = gtkwindow


### PR DESCRIPTION
This generalizes the IJulia detection, allowing users to turn off Winston's backends by specifying their `output_surface` to be `:none`.

Just like IJulia doesn't require a tk/gtk backend, specifying `:none` will prevent loading tk or gtk.  This is useful for saving plots directly to file without launching the GUI frameworks or when using [TerminalExtensions.jl](https://github.com/loladiro/TerminalExtensions.jl).
