### PR TITLE
Avoid use of Gtk name in test/canvas.jl if it isn't loaded

### DIFF
--- a/test/canvas.jl
+++ b/test/canvas.jl
@@ -3,15 +3,9 @@ if Winston.output_surface == :tk
     using Tk
 elseif Winston.output_surface == :gtk
     using Gtk
+    include("canvasgtkcompat.jl")
 else
     error("unsupported output_surface for this test")
-end
-if Winston.output_surface == :gtk
-    # minimalistic compatibility definitions
-    # must be separate from using Gtk expr above
-    const Toplevel = Gtk.WindowLeaf
-    pack(x...;y...) = nothing
-    Canvas(w, x, y) = ((w |> (c=show(Gtk.@Canvas(x,y)))); c)
 end
 
 win = Toplevel("TestCanvas", 400, 200)

--- a/test/canvasgtkcompat.jl
+++ b/test/canvasgtkcompat.jl
@@ -1,0 +1,4 @@
+# minimalistic compatibility definitions
+const Toplevel = Gtk.WindowLeaf
+pack(x...;y...) = nothing
+Canvas(w, x, y) = ((w |> (c=show(Gtk.@Canvas(x,y)))); c)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,0 +1,3 @@
+include("canvas.jl")
+include("crashes.jl")
+include("compare.jl")


### PR DESCRIPTION
Even though it's inside an `if...end` block, the reference to `Gtk` casues a problem whenever a `:tk` output surface is present.
