### PR TITLE
Add legend, grid, and get/remove plot components

### DIFF
--- a/doc/fun/getcomponents.rst
+++ b/doc/fun/getcomponents.rst
@@ -1,0 +1,7 @@
+getcomponents
+===
+
+.. function:: getcomponents(p::FramedPlot) -> Array{PlotComponents,1}
+
+   Get a vector of the plot components contained in ``p''
+

--- a/doc/fun/grid.rst
+++ b/doc/fun/grid.rst
@@ -1,0 +1,8 @@
+grid
+========
+
+.. function:: grid([FramedPlot::p, Bool::truefalse])
+
+   Add or remove a grid in the frame of plot ``p``, according to the
+   value ``truefalse``. Toggle grid if ``truefalse`` is not given.
+

--- a/doc/fun/legend.rst
+++ b/doc/fun/legend.rst
@@ -1,0 +1,13 @@
+legend
+========
+
+.. function:: legend([p], lab [,x, y], ...)
+              legend([p], lab [,xy], ...)
+
+   Add a legend to plot ``p`` (or to the current plot if ``p`` is not specified),
+   assigning the labels defined in the vector of strings ``lab`` to the components
+   of the plot (labels must follow the order of the components).
+   
+   The position of the legend is defined by the coordinates ``x``, ``y``,
+   which can be given separately or in a vector or tuple.
+

--- a/doc/fun/rmcomponents.rst
+++ b/doc/fun/rmcomponents.rst
@@ -1,0 +1,10 @@
+rmcomponents
+===
+
+.. function:: rmcomponents(p::FramedPlot, i::Integer) -> Array{PlotComponents,1}
+              rmcomponents(p::FramedPlot, i::Type)
+              rmcomponents(p::FramedPlot, v::AbstractVector)
+   
+   Remove the components contained in the plot ``p'' as identified by their
+   position or their type (e.g. ``Curve``, ``Points``, ``Legend``, etc.)
+

--- a/src/Winston.jl
+++ b/src/Winston.jl
@@ -60,7 +60,12 @@ export
     getattr,
     setattr,
     style,
-    svg
+    svg,
+    
+    getcomponents,
+    rmcomponents,
+    grid,
+    legend
 
 import Base: copy,
     display,
@@ -1250,6 +1255,36 @@ function compose_interior(self::FramedPlot, device::Renderer, region::BoundingBo
     render(self.x1, context1)
 end
 
+getcomponents(p::FramedPlot, c) = p.([:content1, :content2][c]).components
+getcomponents(p::FramedPlot) = [getcomponents(p,1), getcomponents(p,2)]
+
+rmcomponents(p::FramedPlot, i::Integer, c) = splice!(p.([:content1, :content2][c]).components, i)
+
+function rmcomponents(p::FramedPlot, i::Integer)
+    cont1 = getcomponents(p, 1)
+    cont2 = getcomponents(p, 2)
+    if i <= length(cont1)
+        rmcomponents(p, i, 1)
+    elseif i <= length(cont1) + length(cont2)
+        rmcomponents(p, i - lenght(cont1), 2)
+    else
+        error("Requested remove item #$i from $(length(cont1)+length(cont2)) components.")
+    end
+end
+
+function rmcomponents(p::FramedPlot, v::AbstractVector, args...)
+    eltype(v) <: Integer && sort!(v, rev=true)
+    for i in v
+        rmcomponents(p, i, args...)
+    end
+end
+
+function rmcomponents(p::FramedPlot, t::Type, args...)
+    ctypes = map(typeof, getcomponents(p, args...))
+    todel = find(map(x -> (x <: t), ctypes))
+    rmcomponents(p, todel, args...)
+end
+    
 # Table ------------------------------------------------------------------------
 
 type _Grid

--- a/src/plot.jl
+++ b/src/plot.jl
@@ -580,3 +580,28 @@ function fplot(f::Function, limits, args...; kvs...)
     x,y = fplot_points(f, xmin, xmax; fopts...)
     plot(x, y, pargs...; kvs...)
 end
+
+grid(p::FramedPlot, tf::Bool) = (setattr(p.frame, draw_grid=tf); p)
+grid(p::FramedPlot) = grid(p, !any(map(x->getattr(x, "draw_grid"), p.frame.objs)))
+grid(args...) = grid(_pwinston, args...)
+
+function legend(p::FramedPlot, lab::AbstractVector, args...; kvs...)
+    if length(args) > 0 && length(args[1]) == 2 && eltype(args[1]) <: Real
+        position = args[1]
+        args = args[2:end]
+    elseif length(args) > 1 && eltype(args[1:2]) <: Real
+        position = args[1:2]
+        args = args[3:end]
+    else
+        position = [0.1, 0.9]
+    end
+    # TODO: define other legend positions
+    plotcomp = getcomponents(p)
+    nitems = min(length(lab), length(plotcomp))
+    for c in 1:nitems
+        setattr(plotcomp[c], label=lab[c])
+    end
+    add(p, Legend(position..., plotcomp[1:nitems], args...; kvs...))
+end
+legend(lab::AbstractVector, args...; kvs...) = legend(_pwinston, lab, args...; kvs...)
+


### PR DESCRIPTION
Added the methods "legend" and "grid" to add a legend (using the already existing "Legend" type) and toggle on/off axes grids, more or less in matlab-fashion.

Also added two methods to help manipulate the components of a plot: "getcomponents" (returns the vector of components in a given FramedPlot), and "rmcomponents" (splice the vector of components of the FramedPlot).

