### PR TITLE
Added BoxPainter type (was missing for FillComponent legends)

### DIFF
--- a/src/paint.jl
+++ b/src/paint.jl
@@ -273,6 +273,19 @@ function paint(self::PolygonPainter, context::PaintContext)
     polygon(context.device, self.points)
 end
 
+immutable BoxPainter <: AbstractPainter
+    p::Point
+    q::Point
+end
+
+function boundingbox(self::BoxPainter, context::PaintContext)
+    return BoundingBox(self.p, self.q)
+end
+
+function paint(self::BoxPainter, context::PaintContext)
+    rectangle(context.device, BoundingBox(self.p, self.q))
+end
+
 immutable ImagePainter <: AbstractPainter
     img
     bbox

--- a/src/renderer.jl
+++ b/src/renderer.jl
@@ -256,6 +256,11 @@ function polygon(self::CairoRenderer, points::Vector)
     fill(self.ctx)
 end
 
+function rectangle(self::CairoRenderer, bbox::BoundingBox)
+    rectangle(self.ctx, bbox)
+    fill(self.ctx)
+  end
+
 function layout_text(self::CairoRenderer, str::String)
     set_latex(self.ctx, str, get(self,:fontsize))
 end


### PR DESCRIPTION
make_key(self::FillComponent, bbox::BoundingBox) in Winston.jl (used to make legends of "filled plots") calls the constructor of a "BoxPainter" type, which was not defined anywhere. I have defined it after the model of the "PolygonPainter", and also written a short "rectangle" method for CairoRenderer objects.

(I could have used the already existing "polygon" method inside paint(self::BoxPainter, context::PaintContext), but I think this is more elegant.)