### PR TITLE
Fixing a concat warning

### DIFF
--- a/src/config.jl
+++ b/src/config.jl
@@ -3,7 +3,8 @@ _winston_config = Inifile()
 
 begin
     local fn
-    for dir in [".",Pkg.dir(),LOAD_PATH]
+    _PTH = VERSION<=v"0.4-"? [".",Pkg.dir(),LOAD_PATH]:[".";Pkg.dir();LOAD_PATH]
+    for dir in _PTH
         fn = joinpath(dir, "Winston.ini")
         if isfile(fn) break end
         fn = joinpath(dir, "Winston", "src", "Winston.ini")


### PR DESCRIPTION
Using the new concat syntax in Julia 0.4