### PR TITLE
Use Compat for 0.4 Tuple syntax

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -3,5 +3,5 @@ Cairo
 Color 0.2.9
 IniFile
 Tk
-Compat 0.2.5
+Compat 0.4.0
 Graphics 0.1

--- a/src/Winston.jl
+++ b/src/Winston.jl
@@ -8,6 +8,7 @@ else
     importall Graphics
 end
 using IniFile
+using Compat
 
 export
     closefig,

--- a/src/plot.jl
+++ b/src/plot.jl
@@ -247,7 +247,7 @@ semilogx(args::PlotArg...; kvs...) = plot(args...; xlog=true, kvs...)
 semilogy(args::PlotArg...; kvs...) = plot(args...; ylog=true, kvs...)
 loglog(args::PlotArg...; kvs...) = plot(args...; xlog=true, ylog=true, kvs...)
 
-typealias Interval (Real,Real)
+typealias Interval @compat(Tuple{Real,Real})
 
 function data2rgb{T<:Real}(data::AbstractArray{T}, limits::Interval, colormap::Array{Uint32,1})
     img = similar(data, Uint32)
@@ -403,7 +403,7 @@ spy(S::SparseMatrixCSC) = spy(S, 100, 100)
 spy(A::AbstractMatrix, nrS, ncS) = spy(sparse(A), nrS, ncS)
 spy(A::AbstractMatrix) = spy(sparse(A))
 
-function plothist(p::FramedPlot, h::(Range,Vector); kvs...)
+function plothist(p::FramedPlot, h::@compat(Tuple{Range,Vector}); kvs...)
     c = Histogram(h...)
     add(p, c)
 
@@ -432,7 +432,7 @@ _default_kernel2d=(1.0/273.)*[1.0 4.0 7.0 4.0 1.0;
                              4.0 16. 26. 16. 4.0]
 
 #hist2d
-function plothist2d(p::FramedPlot, h::(Union(Range,Vector),Union(Range,Vector),Array{Int,2}); colormap=_current_colormap, smooth=0, kernel=_default_kernel2d, kvs...)
+function plothist2d(p::FramedPlot, h::@compat(Tuple{Union(Range,Vector),Union(Range,Vector),Array{Int,2}}); colormap=_current_colormap, smooth=0, kernel=_default_kernel2d, kvs...)
     xr, yr, hdata = h
 
     for i in 1:smooth

--- a/src/plot_interfaces.jl
+++ b/src/plot_interfaces.jl
@@ -9,7 +9,7 @@
 ## plot(fs::Array{Function, 2}, a::Real, b::Real, args...; kwargs...) table of plots
 
 
-typealias ScatterPlotPoints{T<:Real, S<:Real} (Vector{T}, Vector{S})
+typealias ScatterPlotPoints{T<:Real, S<:Real} @compat(Tuple{Vector{T}, Vector{S}})
 
 ## plot a scatterplot (verbose alternative to plot(x, y, "o")
 ## use named argument symbol to pass in symbol -- not args)
@@ -21,7 +21,7 @@ end
 errs_to_nan(f) = (x) -> try f(x) catch e NaN end
 
 ## parametric plot
-typealias ParametricFunctionPair (Function, Function)
+typealias ParametricFunctionPair @compat(Tuple{Function, Function})
 function plot(p::FramedPlot, fs::ParametricFunctionPair, a::Real, b::Real, args...; npoints::Int=500, kwargs...)
     us = linspace(a, b, npoints)
     xs = map(errs_to_nan(fs[1]), us)

--- a/src/renderer.jl
+++ b/src/renderer.jl
@@ -61,7 +61,7 @@ end
 
 color_to_rgb(i::Integer) = convert(RGB, RGB24(unsigned(i)))
 color_to_rgb(s::String) = color(s)
-color_to_rgb(rgb::(Real,Real,Real)) = RGB(rgb...)
+color_to_rgb(rgb::@compat(Tuple{Real,Real,Real})) = RGB(rgb...)
 color_to_rgb(cv::ColorValue) = convert(RGB, cv)
 color_to_rgb(cv::AlphaColorValue) = cv
 


### PR DESCRIPTION
Lots of deprecation warnings which I'm not fixing here, but at least the package loads and passes tests for me on Ubuntu 14.04.