### PR TITLE
Timeplot function

### DIFF
--- a/doc/fun/index.rst
+++ b/doc/fun/index.rst
@@ -27,6 +27,7 @@
    stem
    text
    title
+   timeplot
    xlabel
    xlim
    ylabel

--- a/doc/fun/timeplot.rst
+++ b/doc/fun/timeplot.rst
@@ -1,0 +1,28 @@
+timeplot
+========
+
+.. function:: timeplot(p::FramedPlot, x::Array{DateTime,1},y::AbstractArray{T,N},args...; kvs...)
+              timeplot(x::Array{DateTime,1},y::AbstractArray{T,N},args...; kvs...)
+              timeplot(p::FramedPlot,x::Array{Date,1},y::AbstractArray{T,N},arg...; kvs...)
+              timeplot(x::Array{Date,1},y::AbstractArray{T,N},arg...; kvs...)
+
+    Plot a time series where the time is given as a Julia ``DateTime`` or
+    ``Date`` type.
+    The keyword argument ``format`` may be used to specify a date formatting
+    string and is passed to ``strftime`` to format the ticklabels of the x axis.
+    Additional arguments and keyword arguments are passed to ``plot``.
+
+Example
+-------
+
+.. winston::
+
+    using Dates
+
+    t0 = DateTime(Year(2000), Month(3), Day(14), Hour(21), Minute(45))
+    t1 = DateTime(Year(2000), Month(3), Day(14), Hour(22), Minute(22))
+
+    x = collect(t0:Second(1):t1)
+    y = randn(length(x))
+
+    timeplot(x, y, format="%x\n%X")

--- a/src/Winston.jl
+++ b/src/Winston.jl
@@ -11,6 +11,9 @@ using IniFile
 using Compat
 using Dates
 
+isdefined(Base, :Libc) && (strftime = Libc.strftime)
+isdefined(Base, :Dates) && (datetime2unix = Dates.datetime2unix)
+
 export
     closefig,
     colormap,

--- a/src/Winston.jl
+++ b/src/Winston.jl
@@ -9,6 +9,7 @@ else
 end
 using IniFile
 using Compat
+using Dates
 
 export
     closefig,
@@ -32,6 +33,7 @@ export
     stem,
     text,
     title,
+    timeplot,
     xlabel,
     xlim,
     ylabel,

--- a/src/plot.jl
+++ b/src/plot.jl
@@ -605,3 +605,45 @@ function legend(p::FramedPlot, lab::AbstractVector, args...; kvs...)
 end
 legend(lab::AbstractVector, args...; kvs...) = legend(_pwinston, lab, args...; kvs...)
 
+function timeplot(p::FramedPlot, x::Vector{DateTime}, y::AbstractArray, args...; kvs...)
+    limits = datetime2unix([minimum(x), maximum(x)])
+
+    ticks = collect(0.0:0.2:1.0)
+    ticklabels = x[round(Int64, ticks * (length(x) - 1) + 1)]
+    normalized_x = (datetime2unix(x) - limits[1]) / (limits[2] - limits[1])
+
+    span = @compat Int(x[end] - x[1]) / 1000
+    kvs = Dict(kvs)
+
+    if :format in keys(kvs)
+        format = kvs[:format]
+        delete!(kvs, :format)
+    else
+        if span > 365 * 24 * 60 * 60 # 1 year
+            format = "%Y-%m"
+        elseif 365 * 24 * 60 * 60 > span > 30 * 24 * 60 * 60 # 1 month
+            format = "%Y-%m-%d"
+        elseif 30 * 24 * 60 * 60 > span > 24 * 60 * 60 # 1 day
+            format = "%Y-%m-%d\n%H:%M"
+        elseif 24 * 60 * 60 > span > 60 * 60 # 1 hour
+            format = "%H:%M"
+        elseif 60 * 60 > 60 # 1 minute
+            format = "%H:%M:%S"
+        else
+            format = "%H:%M:%S"
+        end
+    end
+
+    ticklabels = map(d -> strftime(format, datetime2unix(d)), ticklabels)
+
+    setattr(p.x1, :ticklabels, ticklabels)
+    setattr(p.x1, :ticks, ticks)
+    setattr(p.x1, :ticklabels_style, @compat Dict(:fontsize=>1.5))
+
+    plot(p, normalized_x, y, args...; kvs...)
+end
+
+timeplot(x::Vector{DateTime}, y::AbstractArray, args...; kvs...) = timeplot(ghf(), x, y, args...; kvs...)
+timeplot(x::Vector{Date}, y::AbstractArray, arg...; kvs...) = timeplot(ghf(), DateTime(x), y, arg...; kvs...)
+timeplot(p::FramedPlot, x::Vector{Date}, y::AbstractArray, arg...; kvs...) =
+    timeplot(p, DateTime(x), y, arg...; kvs...)


### PR DESCRIPTION
New function to plot time series, where the x values are ``DateTime`` or ``Date`` types.
I first tried to implement this as a new method for ``plot`` in ``plot_interfaces.jl``, but it didn't work, so I wrote this instead.
The ticklabels are automatically formatted according to the time span covered by ``x``. Alternatively a date formatting string can be specified. 
Since all additional args and keyword args are passed to ``plot``, scatterplots are possible by specifying a symbol like ``'o'``.

I tested this in Julia 0.3.9 and the latest 0.4 (v"0.4.0-dev+5236").