### PR TITLE
Fix v0.3 compat of barplot

### DIFF
--- a/src/plot.jl
+++ b/src/plot.jl
@@ -582,9 +582,9 @@ function fplot(f::Function, limits, args...; kvs...)
 end
 
 # bar, barh
-ax = Dict{Any,Any}(:bar => :x, :barh => :y)
-ax1 = Dict{Any,Any}(:bar => :x1, :barh => :y1)
-vert = Dict{Any,Any}(:bar => true, :barh => false)
+ax = @compat Dict{Any,Any}(:bar => :x, :barh => :y)
+ax1 = @compat Dict{Any,Any}(:bar => :x1, :barh => :y1)
+vert = @compat Dict{Any,Any}(:bar => true, :barh => false)
 for fn in (:bar, :barh)
     eval(quote
           function $fn(p::FramedPlot, b::FramedBar, args...; kvs...)


### PR DESCRIPTION
My attempt to fix the deprecation warnings for v0.4 (28909d0d82ac32a514acc975842cc53022e0b235) broke compatibility with v0.3, sorry about that.

@nolta: I hope it is okay, if I just merge this, because the fix is rather trivial, but the package fails to load without it in Julia v0.3.9. Please let me know, if it's not okay for you, then I won't merge fixes like this myself in the future.