### PR TITLE
New closeall function and closefig/closeall for the Gtk backend

### DIFF
--- a/doc/fun/closeall.rst
+++ b/doc/fun/closeall.rst
@@ -1,0 +1,7 @@
+closeall
+========
+
+.. function:: closeall()
+
+   Close all currently open figures.
+

--- a/src/Winston.jl
+++ b/src/Winston.jl
@@ -2833,8 +2833,8 @@ if output_surface != :none
     if output_surface == :gtk
         include("gtk.jl")
         window = gtkwindow
-        closefig(i::Integer) = error("not implemented")
-        closeall() = error("not implemented")
+        closefig(i::Integer) = gtkdestroy(getfig(_display,i).window)
+        closeall() = (map(closefig, keys(_display.figs)); nothing)
     elseif output_surface == :tk
         include("tk.jl")
         window = tkwindow

--- a/src/Winston.jl
+++ b/src/Winston.jl
@@ -18,6 +18,7 @@ export
     bar,
     barh,
     closefig,
+    closeall,
     colormap,
     errorbar,
     figure,
@@ -2833,10 +2834,12 @@ if output_surface != :none
         include("gtk.jl")
         window = gtkwindow
         closefig(i::Integer) = error("not implemented")
+        closeall() = error("not implemented")
     elseif output_surface == :tk
         include("tk.jl")
         window = tkwindow
         closefig(i::Integer) = tkdestroy(getfig(_display,i).window)
+        closeall() = (map(closefig, keys(_display.figs)); nothing)
     else
         warn("Selected Winston backend not found. You will not be able to display plots in a window")
     end


### PR DESCRIPTION
The closeall function closes all currently open figures. This fixes #207.

I also enabled closefig and closeall for the Gtk backend. ``gtkdestroy`` was already implemented in src/gtk.jl. I tested this in Julia v0.4 and v0.3 and the latest version of Gtk.jl from JuliaLang/Gtk.jl and it worked. Was there a reason for why ``gtkdestroy`` was not used?