### PR TITLE
Inform Travis that installation requires usage of sudo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: julia
+sudo: required
 os:
   - linux
   - osx
@@ -7,7 +8,6 @@ julia:
   - nightly
 notifications:
   email: false
-sudo: false
 script:
   - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
   - julia -e 'Pkg.clone(pwd()); Pkg.build("Winston")'

--- a/REQUIRE
+++ b/REQUIRE
@@ -5,3 +5,4 @@ IniFile
 Tk
 Compat 0.4.4
 Graphics 0.1
+Dates


### PR DESCRIPTION
This is needed to force the Travis legacy architecture