### PR TITLE
added Dates and Base.* to control flow

### DIFF
--- a/src/Winston.jl
+++ b/src/Winston.jl
@@ -4,12 +4,14 @@ using Cairo
 using Colors
 if VERSION < v"0.4.0-dev+3275"
     importall Base.Graphics
+    using Dates
 else
     importall Graphics
+    using Base.Dates
+    import Base: *
 end
 using IniFile
 using Compat
-using Dates
 isdefined(Base, :Libc) && (strftime = Libc.strftime)
 isdefined(Base, :Dates) && (datetime2unix = Dates.datetime2unix)
 


### PR DESCRIPTION
This removes the following WARNING messages in Julia 0.4
````julia
WARNING: requiring "Dates" in module "Winston" did not define a corresponding module.
WARNING: module Winston should explicitly import * from Base
````
Tests pass on Julia 0.4.0 and fail on Julia 0.3.11, but the failure of `example07` on Julia 0.3.11 is currently an issue that this PR doesn't solve.
