### PR TITLE
Require julia 0.4 and test 0.5 on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ sudo: required
 os:
   - linux
 julia:
-  - 0.3
   - 0.4
+  - 0.5
   - nightly
 notifications:
   email: false

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
-julia 0.2
+julia 0.4
 Cairo
 Colors
 IniFile


### PR DESCRIPTION
Since new 0.3 tags are no longer accepted, let's make the minimum julia 0.4.